### PR TITLE
Modified cell format and markdown in notebook 2.1

### DIFF
--- a/Tutorials/Day_2/Tuto_2.1_Matched_filtering_introduction.ipynb
+++ b/Tutorials/Day_2/Tuto_2.1_Matched_filtering_introduction.ipynb
@@ -10,7 +10,7 @@
    "source": [
     "<img style=\"float: left;padding: 1.3em\" src=\"https://indico.in2p3.fr/event/18313/logo-786578160.png\">  \n",
     "\n",
-    "#  Gravitational Wave Open Data Workshop #3\n",
+    "#  Gravitational Wave Open Data Workshop #4\n",
     "\n",
     "\n",
     "## Tutorial 2.1 PyCBC Tutorial, An introduction to matched-filtering\n",
@@ -51,7 +51,7 @@
    "outputs": [],
    "source": [
     "# -- Use the following for Google Colab\n",
-    "#! pip install -q 'lalsuite==6.66' 'PyCBC==1.15.3' "
+    "#! pip install -q 'lalsuite==6.82'' 'PyCBC==1.18.0' "
    ]
   },
   {

--- a/Tutorials/Day_2/Tuto_2.1_Matched_filtering_introduction.ipynb
+++ b/Tutorials/Day_2/Tuto_2.1_Matched_filtering_introduction.ipynb
@@ -17,7 +17,7 @@
     "\n",
     "We will be using the [PyCBC](http://github.com/ligo-cbc/pycbc) library, which is used to study gravitational-wave data, find astrophysical sources due to compact binary mergers, and study their parameters. These are some of the same tools that the LIGO and Virgo collaborations use to find gravitational waves in LIGO/Virgo data \n",
     "\n",
-    "In this tutorial we will walk through how find a specific signal in LIGO data. We present matched filtering as a cross-correlation, in both the time domain and the frequency domain. In the next tutorial (2.2), we use the method as encoded in PyCBC, which is optimal in the case of Gaussian noise and a known signal model. In reality our noise is not entirely Gaussian, and in practice we use a variety of techniques to separate signals from noise in addition to the use of the matched filter. \n",
+    "In this tutorial we will walk through how to find a specific signal in LIGO data. We present matched filtering as a cross-correlation, in both the time domain and the frequency domain. In the next tutorial (2.2), we use the method as encoded in PyCBC, which is optimal in the case of Gaussian noise and a known signal model. In reality our noise is not entirely Gaussian, and in practice we use a variety of techniques to separate signals from noise in addition to the use of the matched filter. \n",
     "\n",
     "[Click this link to view this tutorial in Google Colaboratory](https://colab.research.google.com/github/gw-odw/odw-2020/blob/master/Day_2/Tuto_2.1_Matched_filtering_introduction.ipynb)\n",
     "\n",
@@ -73,9 +73,9 @@
     "id": "n1n6Ut_v0psP"
    },
    "source": [
-    "### Matched-filtering: Finding well modelled signals in Gaussian noise\n",
+    "## Matched-filtering: Finding well modelled signals in Gaussian noise\n",
     "\n",
-    "Matched filtering can be shown to be the optimal method for \"detecting\" signals---when the signal waveform is known---in Gaussian noise. We'll explore those assumptions a little later, but for now let's demonstrate how this works.\n",
+    "Matched filtering can be shown to be the optimal method for \"detecting\" _known_ signals in _Gaussian_ noise. We'll explore those two assumptions a little later, but for now let's demonstrate how this works.\n",
     "\n",
     "Let's assume you have a stretch of noise, white noise to start:"
    ]
@@ -116,6 +116,60 @@
    },
    "source": [
     "And then let's add a gravitational wave signal to some random part of this data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pycbc.waveform import get_td_waveform\n",
+    "\n",
+    "# the \"approximant\" (jargon for parameterized waveform family).\n",
+    "# IMRPhenomD (a phenomenological Inspiral–Merger–Ringdown wafeform model) is defined in the frequency domain, but we'll get it in the time domain (td).\n",
+    "# It runs fast, but it doesn't include effects such as non-aligned component spin, or higher order modes.\n",
+    "apx = 'IMRPhenomD'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can specify [many parameters](https://pycbc.org/pycbc/latest/html/pycbc.waveform.html?highlight=get_td_waveform#pycbc.waveform.waveform.get_td_waveform), but here, we'll use defaults for everything except the masses.\n",
+    "\n",
+    "`get_td_waveform` returns both $h_+$ and $h_{\\times}$, but we'll only use $h_+$ for now."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hp1, _ = get_td_waveform(approximant=apx,\n",
+    "                         mass1=10,\n",
+    "                         mass2=10,\n",
+    "                         delta_t=1.0/sample_rate,\n",
+    "                         f_lower=25)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The amplitude of gravitational-wave signals is normally of order 1E-20. To demonstrate our method on white noise with amplitude O(1) we normalize our signal so the cross-correlation of the signal with itself will give a value of 1.\n",
+    "\n",
+    "In this case we can interpret the cross-correlation of the signal with white noise as a signal-to-noise ratio."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hp1 = hp1 / max(numpy.correlate(hp1, hp1, mode='full'))**0.5"
    ]
   },
   {
@@ -180,30 +234,6 @@
     }
    ],
    "source": [
-    "from pycbc.waveform import get_td_waveform\n",
-    "\n",
-    "# the \"approximant\" (jargon for parameterized waveform family).\n",
-    "# IMRPhenomD is defined in the frequency domain, but we'll get it in the time domain (td).\n",
-    "# It runs fast, but it doesn't include effects such as non-aligned component spin, or higher order modes.\n",
-    "apx = 'IMRPhenomD'\n",
-    "\n",
-    "# You can specify many parameters, \n",
-    "# https://pycbc.org/pycbc/latest/html/pycbc.waveform.html?highlight=get_td_waveform#pycbc.waveform.waveform.get_td_waveform\n",
-    "# but here, we'll use defaults for everything except the masses.\n",
-    "# It returns both hplus and hcross, but we'll only use hplus for now.\n",
-    "hp1, _ = get_td_waveform(approximant=apx,\n",
-    "                         mass1=10,\n",
-    "                         mass2=10,\n",
-    "                         delta_t=1.0/sample_rate,\n",
-    "                         f_lower=25)\n",
-    "\n",
-    "# The amplitude of gravitational-wave signals is normally of order 1E-20. To demonstrate our method\n",
-    "# on white noise with amplitude O(1) we normalize our signal so the cross-correlation of the signal with\n",
-    "# itself will give a value of 1. In this case we can interpret the cross-correlation of the signal with white\n",
-    "# noise as a signal-to-noise ratio.\n",
-    "\n",
-    "hp1 = hp1 / max(numpy.correlate(hp1,hp1, mode='full'))**0.5\n",
-    "\n",
     "# note that in this figure, the waveform amplitude is of order 1.\n",
     "# The duration (for frequency above f_lower=25 Hz) is only 3 or 4 seconds long.\n",
     "# The waveform is \"tapered\": slowly ramped up from zero to full strength, over the first second or so.\n",
@@ -296,6 +326,13 @@
     "pylab.plot([waveform_start/float(sample_rate), waveform_start/float(sample_rate)], [-10,10],'r:')\n",
     "pylab.xlabel('Time (s)')\n",
     "pylab.ylabel('Cross-correlation')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Detection in Colored Noise"
    ]
   },
   {
@@ -485,11 +522,30 @@
     "\n",
     "* Histogram the whitened time series. Ignoring the outliers associated with the signal, is it a Gaussian? What is the mean and standard deviation? (We have not been careful in normalizing the whitened data properly).\n",
     "* Histogram the above cross-correlation time series. Ignoring the outliers associated with the signal, is it a Gaussian? What is the mean and standard deviation?\n",
-    "* Find the location of the peak. (Note that here, it can be positive or negative), and the value of the SNR of the signal (which is the absolute value of the peak value, divided by the standard deviation of the cross-correlation time series).\n",
-    "\n",
+    "* Find the location of the peak. (Note that here, it can be positive or negative), and the value of the SNR of the signal (which is the absolute value of the peak value, divided by the standard deviation of the cross-correlation time series)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Optional challenge question. much harder:\n",
     "* Repeat this process, but instead of using a waveform with mass1=mass2=10, try 15, 20, or 25. Plot the SNR vs mass. Careful! Using lower masses (eg, mass1=mass2=1.4 Msun) will not work here. Why?"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
This is only a suggestion about formatting the notebook, converting some python comments to markdown cells and breaking up a large cell into smaller ones.

Please disregard if style is not under revision (I still have to run the notebook under the Conda environment).
