### PR TITLE
Remove reference to GW150914 from Tutorial 1.2

### DIFF
--- a/Tutorials/Day_1/Tuto 1.2 Open Data access with GWpy.ipynb
+++ b/Tutorials/Day_1/Tuto 1.2 Open Data access with GWpy.ipynb
@@ -134,7 +134,7 @@
     "#### Finding open data\n",
     "\n",
     "We have seen already that the `gwosc` module can be used to query for what data are available on [GWOSC](https://www.gw-openscience.org/data/).\n",
-    "The next thing to do is to actually read some open data. Let's try to get some for GW150914, the first direct detection of an astrophysical gravitational-wave signal from a BBH (binary black hole system).\n",
+    "The next thing to do is to actually read some open data. Let's try to get some for GW190412, the first detection of a gravitational-wave signal from an unequal-mass BBH (binary black hole system).\n",
     "\n",
     "We can use the [`TimeSeries.fetch_open_data`](https://gwpy.github.io/docs/stable/api/gwpy.timeseries.TimeSeries.html#gwpy.timeseries.TimeSeries.fetch_open_data) method to download data directly from https://www.gw-openscience.org, but we need to know the GPS times.\n",
     "We can query for the GPS time of an event as follows:"

--- a/Tutorials/Day_1/Tuto 1.2 Open Data access with GWpy.ipynb
+++ b/Tutorials/Day_1/Tuto 1.2 Open Data access with GWpy.ipynb
@@ -105,7 +105,7 @@
    "source": [
     "## A note on object-oriented programming\n",
     "\n",
-    "Before we dive too deeply, its worth a quick aside on object-oriented programming (OOP).\n",
+    "Before we dive too deeply, it's worth a quick aside on object-oriented programming (OOP).\n",
     "[GWpy](https://gwpy.github.io/docs/stable/index.html) is heavily object-oriented, meaning almost all of the code you run using GWpy is based around an object of some type, e.g. `TimeSeries`.\n",
     "Most of the methods (functions) we will use are attached to an object, rather than standing alone, meaning you should have a pretty good idea of what sort of data you are dealing with (without having to read the documentation!).\n",
     "\n",
@@ -268,7 +268,7 @@
    },
    "source": [
     "<div class=\"alert alert-info\">\n",
-    "Since this is the first time we are plotting something in this notebook, we need to make configure `matplotlib` (the plotting library) to work within the notebook properly:\n",
+    "Since this is the first time we are plotting something in this notebook, we need to configure `matplotlib` (the plotting library) to work within the notebook properly:\n",
     "</div>"
    ]
   },
@@ -310,7 +310,7 @@
     "id": "1irX8-UnvvXd"
    },
    "source": [
-    "Notes: There are alternatives ways to access the GWOSC data. \n",
+    "Notes: There are alternative ways to access the GWOSC data. \n",
     "\n",
     "* [`readligo`](https://losc.ligo.org/s/sample_code/readligo.py) is a light-weight Python module that returns the time series into a Numpy array.\n",
     "* The [PyCBC](http://github.com/ligo-cbc/pycbc) package has the `pycbc.frame.query_and_read_frame` and `pycbc.frame.read_frame` methods. We use [PyCBC](http://github.com/ligo-cbc/pycbc) in Tutorial 2.1, 2.2 and 2.3. "
@@ -462,7 +462,7 @@
    "source": [
     "## Calculating the power spectral density\n",
     "\n",
-    "In practice, we typically use a large number of FFTs to estimate an averages power spectral density over a long period of data.\n",
+    "In practice, we typically use a large number of FFTs to estimate an average power spectral density over a long period of data.\n",
     "We can do this using the [`asd()`](https://gwpy.github.io/docs/stable/api/gwpy.timeseries.TimeSeries.html#gwpy.timeseries.TimeSeries.asd) method, which uses [Welch's method](https://en.wikipedia.org/wiki/Welch%27s_method) to combine FFTs of overlapping, windowed chunks of data."
    ]
   },
@@ -559,7 +559,7 @@
     "id": "XehA6HMUvvX-"
    },
    "source": [
-    "Now we can see some more features, including sets of lines around ~30 Hz and ~65 Hz, and some more isolate lines through the more sensitive region.\n",
+    "Now we can see some more features, including sets of lines around ~30 Hz and ~65 Hz, and some more isolated lines through the more sensitive region.\n",
     "\n",
     "For comparison, we can load the LIGO-Hanford data and plot that as well:"
    ]


### PR DESCRIPTION
There was a residual reference to GW150914 in Tutorial 1.2, which was switched to use data from GW190412 instead. I have just updated the text that still mentioned GW150914.