### PR TITLE
Update Tuto_3.2_Parameter_estimation_for_compact_object_mergers.ipynb

### DIFF
--- a/Tutorials/Day_3/Tuto_3.2_Parameter_estimation_for_compact_object_mergers.ipynb
+++ b/Tutorials/Day_3/Tuto_3.2_Parameter_estimation_for_compact_object_mergers.ipynb
@@ -86,8 +86,8 @@
    },
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
     "from __future__ import division, print_function\n",
+    "%matplotlib inline\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "\n",


### PR DESCRIPTION
Put the "from __future__ import division, print_function" as the first line to avoid the bug in operation.